### PR TITLE
47 disable tqdm when running non interactive

### DIFF
--- a/src/pyaro_readers/aeronetsdareader/AeronetSdaTimeseriesReader.py
+++ b/src/pyaro_readers/aeronetsdareader/AeronetSdaTimeseriesReader.py
@@ -129,7 +129,11 @@ class AeronetSdaTimeseriesReader(AutoFilterReaderEngine.AutoFilterReader):
                         lines = []
                         _fidx = 0
                         members = tf.getmembers()
-                        bar = tqdm(desc="extracting tar file...", total=len(members), disable=None)
+                        bar = tqdm(
+                            desc="extracting tar file...",
+                            total=len(members),
+                            disable=None,
+                        )
                         for _midx, member in enumerate(members):
                             if fnmatch(member.name, FILE_MASK):
                                 bar.update(1)

--- a/src/pyaro_readers/aeronetsdareader/AeronetSdaTimeseriesReader.py
+++ b/src/pyaro_readers/aeronetsdareader/AeronetSdaTimeseriesReader.py
@@ -129,7 +129,7 @@ class AeronetSdaTimeseriesReader(AutoFilterReaderEngine.AutoFilterReader):
                         lines = []
                         _fidx = 0
                         members = tf.getmembers()
-                        bar = tqdm(desc="extracting tar file...", total=len(members))
+                        bar = tqdm(desc="extracting tar file...", total=len(members), disable=None)
                         for _midx, member in enumerate(members):
                             if fnmatch(member.name, FILE_MASK):
                                 bar.update(1)
@@ -171,7 +171,7 @@ class AeronetSdaTimeseriesReader(AutoFilterReaderEngine.AutoFilterReader):
 
         gcd = Geocoder_Reverse_NE()
         crd = csv.DictReader(lines, fieldnames=self._fields, delimiter=DELIMITER)
-        bar = tqdm(desc=tqdm_desc, total=len(lines))
+        bar = tqdm(desc=tqdm_desc, total=len(lines), disable=None)
         for _ridx, row in enumerate(crd):
             bar.update(1)
             if row[SITE_NAME] != _laststatstr:

--- a/src/pyaro_readers/aeronetsunreader/AeronetSunTimeseriesReader.py
+++ b/src/pyaro_readers/aeronetsunreader/AeronetSunTimeseriesReader.py
@@ -118,7 +118,7 @@ class AeronetSunTimeseriesReader(AutoFilterReaderEngine.AutoFilterReader):
 
         gcd = Geocoder_Reverse_NE()
         crd = csv.DictReader(lines, fieldnames=self._fields, delimiter=DELIMITER)
-        bar = tqdm(desc=tqdm_desc, total=len(lines))
+        bar = tqdm(desc=tqdm_desc, total=len(lines), disable=None)
         for _ridx, row in enumerate(crd):
             bar.update(1)
             if row[SITE_NAME] != _laststatstr:

--- a/src/pyaro_readers/harpreader/harpreader.py
+++ b/src/pyaro_readers/harpreader/harpreader.py
@@ -73,7 +73,7 @@ class AeronetHARPReader(AutoFilterReaderEngine.AutoFilterReader):
         else:
             self._files.append(file)
 
-        bar = tqdm(total=len(self._files))
+        bar = tqdm(total=len(self._files), disable=None)
 
         for f_idx, _file in enumerate(self._files):
             logger.info(f"Reading {_file}")

--- a/src/pyaro_readers/nilupmfabsorptionreader/NILUPMFAbsorptionReader.py
+++ b/src/pyaro_readers/nilupmfabsorptionreader/NILUPMFAbsorptionReader.py
@@ -86,7 +86,7 @@ class NILUPMFAbsorptionReader(AutoFilterReaderEngine.AutoFilterReader):
                 raise ValueError(
                     f"Could not find any nas files in given folder {self._filename}"
                 )
-            bar = tqdm(desc=tqdm_desc, total=len(files))
+            bar = tqdm(desc=tqdm_desc, total=len(files), disable=None)
             for file in files:
                 bar.update(1)
                 self._process_file(file, fill_country_flag)

--- a/src/pyaro_readers/nilupmfebas/EbasPmfReader.py
+++ b/src/pyaro_readers/nilupmfebas/EbasPmfReader.py
@@ -60,7 +60,7 @@ class EbasPmfTimeseriesReader(AutoFilterReaderEngine.AutoFilterReader):
         if Path(realpath).is_dir():
             # search directory for files
             files = list(realpath.glob(filemask))
-            bar = tqdm(desc=tqdm_desc, total=len(files))
+            bar = tqdm(desc=tqdm_desc, total=len(files), disable=None)
 
             for _ridx, file in enumerate(files):
                 bar.update(1)


### PR DESCRIPTION
Adding disable=None to all `tqdm()` calls

closes #47 