### PR TITLE
Fixes for the merging_reader

### DIFF
--- a/src/pyaro_readers/merging_reader.py
+++ b/src/pyaro_readers/merging_reader.py
@@ -150,9 +150,26 @@ class MergingReader(AutoFilterReader):
             variables.extend(d.variables())
         return variables
 
-    def close(self):
+    def close(self) -> None:
         for d in self._datasets:
             d.close()
+
+    def metadata(self) -> dict[str, str]:
+        all_metadata = [d.metadata() for d in self._datasets]
+        all_metadata_keys = set()
+        for m in all_metadata:
+            all_metadata_keys |= m.keys()
+
+        metadata = dict()
+        for key in sorted(all_metadata_keys):
+            values = [m.get(key, "none") for m in all_metadata]
+            if all((v == values[0] for v in values)):
+                # All datasets report the same metadata
+                metadata[key] = values[0]
+            else:
+                metadata[key] = "-".join(values)
+
+        return metadata
 
 
 class MergingReaderEngine(AutoFilterEngine):

--- a/src/pyaro_readers/merging_reader.py
+++ b/src/pyaro_readers/merging_reader.py
@@ -119,9 +119,8 @@ class MergingReader(AutoFilterReader):
         raise MergingReaderException("This method should not be called")
 
     def data(self, varname: str) -> Data:
-        """This method is deliberately overridden to prevent
-        double filtering of the data
-        """
+        # This method is deliberately overridden to prevent
+        # double filtering of the data
         return MergingReaderConcatData(
             [d.data(varname) for d in self._datasets], varname
         )
@@ -130,9 +129,8 @@ class MergingReader(AutoFilterReader):
         raise MergingReaderException("This method should not be called")
 
     def stations(self) -> dict[str, Station]:
-        """This method is deliberately overridden to prevent
-        double filtering of the data
-        """
+        # This method is deliberately overridden to prevent
+        # double filtering of the data
         stations = {}
         for d in self._datasets:
             stations |= d.stations()
@@ -142,9 +140,8 @@ class MergingReader(AutoFilterReader):
         raise MergingReaderException("This method should not be called")
 
     def variables(self) -> list[str]:
-        """This method is deliberately overridden to prevent
-        double filtering of the data
-        """
+        # This method is deliberately overridden to prevent
+        # double filtering of the data
         variables = []
         for d in self._datasets:
             variables.extend(d.variables())

--- a/src/pyaro_readers/merging_reader.py
+++ b/src/pyaro_readers/merging_reader.py
@@ -116,17 +116,35 @@ class MergingReader(AutoFilterReader):
             )
 
     def _unfiltered_data(self, varname: str) -> Data:
+        raise MergingReaderException("This method should not be called")
+
+    def data(self, varname: str) -> Data:
+        """This method is deliberately overridden to prevent
+        double filtering of the data
+        """
         return MergingReaderConcatData(
             [d.data(varname) for d in self._datasets], varname
         )
 
     def _unfiltered_stations(self) -> dict[str, Station]:
+        raise MergingReaderException("This method should not be called")
+
+    def stations(self) -> dict[str, Station]:
+        """This method is deliberately overridden to prevent
+        double filtering of the data
+        """
         stations = {}
         for d in self._datasets:
             stations |= d.stations()
         return stations
 
     def _unfiltered_variables(self) -> list[str]:
+        raise MergingReaderException("This method should not be called")
+
+    def variables(self) -> list[str]:
+        """This method is deliberately overridden to prevent
+        double filtering of the data
+        """
         variables = []
         for d in self._datasets:
             variables.extend(d.variables())

--- a/tests/test_merginreader.py
+++ b/tests/test_merginreader.py
@@ -20,3 +20,5 @@ def test_stuff():
         ts.variables()
         ts.stations()
         _data = ts.data("sulphur_dioxide_in_air")
+
+        _metadata = ts.metadata()


### PR DESCRIPTION
The merging_reader would apply filters twice: Once on each sub-reader, then on the concatted data. I don't think we have any filters which breaks due to this. I choose to override `data`, `stations`, and `variables` for this to keep filter functionality such as `supported_filters` which is difficult to support if not using `AutoFilterReader`.

The merging_reader would blank out all metadata, including `revision`. metadata is now forwarded