### PR TITLE
Station duplicate leads to wrong-sized join

### DIFF
--- a/src/pyaro_readers/eeareader/EEATimeseriesReader.py
+++ b/src/pyaro_readers/eeareader/EEATimeseriesReader.py
@@ -47,7 +47,9 @@ class EEAData(Data):
                 (polars.col("Country Code") + "/" + polars.col("Sampling Point Id"))
                 .str.replace("/", "_")
                 .alias("station")
-            ).select("station", "Longitude", "Latitude", "Altitude"),
+            )
+            .select("station", "Longitude", "Latitude", "Altitude")
+            .unique("station"),
             on="station",
         )
         return joined


### PR DESCRIPTION
Seen when working on the unverified data without valleyfloor filter, where two stations with different tstype are in the metadata