### PR TITLE
Skip units for empty datasets

### DIFF
--- a/src/pyaro_readers/merging_reader.py
+++ b/src/pyaro_readers/merging_reader.py
@@ -41,9 +41,8 @@ class MergingReaderConcatData(Data):
                     f"The units are not the same in all the datasets {base_unit} {d.units}"
                 )
         if base_unit is None:
-            raise MergingReaderException(
-                "This dataset is empty or does not contain any units"
-            )
+            # Fallback to units from first dataset even if it is empty
+            base_unit = self._data[0].units
         return base_unit
 
     def keys(self):

--- a/src/pyaro_readers/merging_reader.py
+++ b/src/pyaro_readers/merging_reader.py
@@ -11,7 +11,7 @@ from pyaro.timeseries import (
     Data,
 )
 import pyaro.timeseries
-from pyaro.timeseries.Filter import FilterFactory
+from pyaro.timeseries.Filter import FilterFactory, FilterCollection
 
 
 class MergingReaderException(Exception):
@@ -27,13 +27,23 @@ class MergingReaderConcatData(Data):
 
     @property
     def units(self) -> str:
-        base_unit = self._data[0].units
-        unit = cf_units.Unit(base_unit)
-        for d in self._data[1:]:
+        base_unit = None
+        for d in self._data:
+            if len(d) == 0:
+                continue
+            if base_unit is None:
+                base_unit = d.units
+                continue
+
+            unit = cf_units.Unit(base_unit)
             if unit.convert(1, d.units) != 1.0:
                 raise MergingReaderException(
                     f"The units are not the same in all the datasets {base_unit} {d.units}"
                 )
+        if base_unit is None:
+            raise MergingReaderException(
+                "This dataset is empty or does not contain any units"
+            )
         return base_unit
 
     def keys(self):
@@ -103,12 +113,13 @@ class MergingReader(AutoFilterReader):
             filename = d.pop("filename_or_obj_or_url")
             if "filters" in d:
                 reader_filters = d.pop("filters")
+                reader_filters = FilterCollection(filterlist=reader_filters)
                 if isinstance(filters, dict):
                     filtlist = []
                     for name, kwargs in filters.items():
                         filtlist.append(FilterFactory().get(name, **kwargs))
                     reader_filters = filtlist
-                filters = self._get_filters() + reader_filters
+                filters = self._get_filters() + list(reader_filters)
             else:
                 filters = self._get_filters()
             self._datasets.append(

--- a/tests/test_merginreader.py
+++ b/tests/test_merginreader.py
@@ -1,6 +1,7 @@
 import os
 
 import pyaro
+from pyaro_readers.merging_reader import MergingReader
 
 EBAS_URL = file = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), "testdata", "NILU"
@@ -22,3 +23,17 @@ def test_stuff():
         _data = ts.data("sulphur_dioxide_in_air")
 
         _metadata = ts.metadata()
+
+
+def test_with_zero_len_dataset():
+    d0 = {"reader_id": "ascii2netcdf", "filename_or_obj_or_url": EBAS_URL}
+    d1 = {
+        "reader_id": "ascii2netcdf",
+        "filename_or_obj_or_url": EBAS_URL,
+        "filters": {"stations": {"include": ["gibberish-non-existent-station"]}},
+    }
+    reader = MergingReader([d0, d1], mode="concat", filters=[])
+
+    data = reader.data("sulphur_dioxide_in_air")
+    _units = data.units
+    _values = data.values


### PR DESCRIPTION
Units does not make sense for empty datasets, and would error if one reader had zero data, such as for the eeareader with some filters enabled. This PR skips empty datasets when requesting units