### PR TITLE
Emit additional fields for EEA reader

### DIFF
--- a/src/pyaro_readers/eeareader/EEATimeseriesReader.py
+++ b/src/pyaro_readers/eeareader/EEATimeseriesReader.py
@@ -354,6 +354,7 @@ def _metadata_to_stations(metadata: polars.DataFrame) -> dict[str, Station]:
         ),
         polars.col("Air Quality Station Area").alias("station_area"),
         polars.col("Air Quality Station Type").alias("station_type"),
+        polars.col("Air Quality Station EoI Code").alias("display_name"),
     ).select(
         [
             "station",
@@ -365,6 +366,7 @@ def _metadata_to_stations(metadata: polars.DataFrame) -> dict[str, Station]:
             "station_area",
             "station_type",
             "long_name",
+            "display_name",
         ]
     )
     station_dicts = {s["station"]: Station(s) for s in stations.to_dicts()}

--- a/src/pyaro_readers/eeareader/EEATimeseriesReader.py
+++ b/src/pyaro_readers/eeareader/EEATimeseriesReader.py
@@ -338,7 +338,38 @@ def _read_daily_files(
     return joined
 
 
-def _metadata_to_stations(metadata: polars.DataFrame) -> dict[str, Station]:
+class EEAStation(Station):
+    def __init__(self, fields: dict | None = None) -> None:
+        self._fields = {
+            "station": "",
+            "latitude": float("nan"),
+            "longitude": float("nan"),
+            "altitude": float("nan"),
+            "long_name": "",
+            "country": "",
+            "url": "",
+            "station_area": "",
+            "station_type": "",
+            "display_name": "",
+        }
+        self._metadata = {}
+        if fields:
+            self.set_fields(fields)
+
+    @property
+    def station_area(self) -> str:
+        self._fields["station_area"]
+
+    @property
+    def station_type(self) -> str:
+        self._fields["station_type"]
+
+    @property
+    def display_name(self) -> str:
+        self._fields["display_name"]
+
+
+def _metadata_to_stations(metadata: polars.DataFrame) -> dict[str, EEAStation]:
     stations = metadata.with_columns(
         # polars.col("Sampling Point Id").alias("station"),
         polars.col("Latitude").alias("latitude"),
@@ -369,7 +400,7 @@ def _metadata_to_stations(metadata: polars.DataFrame) -> dict[str, Station]:
             "display_name",
         ]
     )
-    station_dicts = {s["station"]: Station(s) for s in stations.to_dicts()}
+    station_dicts = {s["station"]: EEAStation(s) for s in stations.to_dicts()}
     return station_dicts
 
 


### PR DESCRIPTION
`station_name` is used internally in the reader for metadata filtering. This PR makes the EEA reader emit `display_name` which is used in https://github.com/metno/pyaerocom/pull/1634 for displaying the shorter station names

See the result at https://aeroval-test.met.no/magnusu/pages/evaluation/?project=eeareadertest&experiment=display-name

As a note the `Station` type from `pyaro` could be made smarter so it does not have to be subclassed for every reader