### PR TITLE
metadata coherence

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyaro_readers
-version = 0.1.6.dev0
+version = 0.1.6
 author = MET Norway
 description = implementations of pyaerocom reading plugings using pyaro as interface
 long_description = file: README.md

--- a/src/pyaro_readers/eeareader/EEATimeseriesReader.py
+++ b/src/pyaro_readers/eeareader/EEATimeseriesReader.py
@@ -51,6 +51,7 @@ class EEAData(Data):
             .select("station", "Longitude", "Latitude", "Altitude")
             .unique("station"),
             on="station",
+            how="left",
         )
         return joined
 
@@ -479,7 +480,7 @@ class EEATimeseriesReader(AutoFilterReader):
     def _unfiltered_data(self, varname: str) -> Data:
         dataframe, metadata = self._read(varname)
         dataframe = dataframe.with_columns(
-            polars.col("Samplingpoint").str.replace("/", "_").alias("station")
+            polars.col("Samplingpoint").str.replace_many({"GI/":"GB_","/":"_"}).alias("station")
         )
         return EEAData(dataframe, varname, metadata)
 

--- a/src/pyaro_readers/eeareader/EEATimeseriesReader.py
+++ b/src/pyaro_readers/eeareader/EEATimeseriesReader.py
@@ -480,7 +480,9 @@ class EEATimeseriesReader(AutoFilterReader):
     def _unfiltered_data(self, varname: str) -> Data:
         dataframe, metadata = self._read(varname)
         dataframe = dataframe.with_columns(
-            polars.col("Samplingpoint").str.replace_many({"GI/":"GB_","/":"_"}).alias("station")
+            polars.col("Samplingpoint")
+            .str.replace_many({"GI/": "GB_", "/": "_"})
+            .alias("station")
         )
         return EEAData(dataframe, varname, metadata)
 


### PR DESCRIPTION
having the `station` column defined with different strategies (https://github.com/metno/pyaro-readers/blob/main-dev/src/pyaro_readers/eeareader/EEATimeseriesReader.py#L47 vs https://github.com/metno/pyaro-readers/blob/main-dev/src/pyaro_readers/eeareader/EEATimeseriesReader.py#L482) creates incoherence in the case of Gibraltar data, where Samplingpoint and Country Code are intrinsically incoherent..  
this fix restores coherence by handling Gibraltar as a special case  

in `joined` a left join is also enforced to ensure dimensional coherence

